### PR TITLE
Use new build hex pm urls (#214)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 
 * Erlang - Prebuilt packages (17.5, 17.4, etc)
   * The full list of prebuilt packages can be found here: 
-    * gigalixir-20 or heroku-20 stacks: https://repo.hex.pm/builds/otp/ubuntu-20.04/builds.txt
-    * heroku-22 stacks: https://repo.hex.pm/builds/otp/ubuntu-22.04/builds.txt
+    * gigalixir-20 or heroku-20 stacks: https://builds.hex.pm/builds/otp/ubuntu-20.04/builds.txt
+    * heroku-22 stacks: https://builds.hex.pm/builds/otp/ubuntu-22.04/builds.txt
     * All other stacks: https://github.com/HashNuke/heroku-buildpack-elixir-otp-builds/blob/master/otp-versions
 * Elixir - Prebuilt releases (1.0.4, 1.0.3, etc) or prebuilt branches (master, v1.7, etc)
   * The full list of releases can be found here: https://github.com/elixir-lang/elixir/releases

--- a/lib/canonical_version.sh
+++ b/lib/canonical_version.sh
@@ -3,10 +3,10 @@
 erlang_builds_url() {
   case "${STACK}" in
     "heroku-20")
-      erlang_builds_url="https://repo.hex.pm/builds/otp/ubuntu-20.04"
+      erlang_builds_url="https://builds.hex.pm/builds/otp/ubuntu-20.04"
       ;;
     "heroku-22")
-      erlang_builds_url="https://repo.hex.pm/builds/otp/ubuntu-22.04"
+      erlang_builds_url="https://builds.hex.pm/builds/otp/ubuntu-22.04"
       ;;
     *)
       erlang_builds_url="https://s3.amazonaws.com/heroku-buildpack-elixir/erlang/cedar-14"
@@ -16,18 +16,18 @@ erlang_builds_url() {
 }
 
 fetch_elixir_versions() {
-  url="https://repo.hex.pm/builds/elixir/builds.txt"
+  url="https://builds.hex.pm/builds/elixir/builds.txt"
   curl -s "$url" | awk '/^v[0-9.]+[- ]/ { print $1 }'
 }
 
 fetch_erlang_versions() {
   case "${STACK}" in
     "heroku-20")
-      url="https://repo.hex.pm/builds/otp/ubuntu-20.04/builds.txt"
+      url="https://builds.hex.pm/builds/otp/ubuntu-20.04/builds.txt"
       curl -s "$url" | awk '/^OTP-([0-9.]+ )/ {print substr($1,5)}'
       ;;
     "heroku-22")
-      url="https://repo.hex.pm/builds/otp/ubuntu-22.04/builds.txt"
+      url="https://builds.hex.pm/builds/otp/ubuntu-22.04/builds.txt"
       curl -s "$url" | awk '/^OTP-([0-9.]+ )/ {print substr($1,5)}'
       ;;
     *)

--- a/lib/elixir_funcs.sh
+++ b/lib/elixir_funcs.sh
@@ -7,7 +7,7 @@ function download_elixir() {
     elixir_changed=true
     local otp_version=$(otp_version ${erlang_version})
 
-    local download_url="https://repo.hex.pm/builds/elixir/${elixir_version}-otp-${otp_version}.zip"
+    local download_url="https://builds.hex.pm/builds/elixir/${elixir_version}-otp-${otp_version}.zip"
 
     output_section "Fetching Elixir ${elixir_version} for OTP ${otp_version} from ${download_url}"
 
@@ -15,7 +15,7 @@ function download_elixir() {
 
     if [ $? -ne 0 ]; then
       output_section "Falling back to fetching Elixir ${elixir_version} for generic OTP version"
-      local download_url="https://repo.hex.pm/builds/elixir/${elixir_version}.zip"
+      local download_url="https://builds.hex.pm/builds/elixir/${elixir_version}.zip"
       curl -s ${download_url} -o $(elixir_cache_path)/$(elixir_download_file) || exit 1
     fi
   else


### PR DESCRIPTION
* Follow redirects to repo.hex.pm

* use builds.hex.pm URLs rather than deprecated repo.hex.pm URLs

From https://hex.pm/blog/new-domain-for-build-artifacts

Currently the curl calls aren't causing redirects to be followed. So the calls to `fetch_elixir_versions` and `fetch_erlang_versions` silently fail, and return no data, resulting in "Sorry, Erlang version isn't supported yet" error.

Could follow redirects, but better fix is to update to use new URLs

---------